### PR TITLE
✨ Feat: 페이지네이션 공통 컴포넌트 구현

### DIFF
--- a/components/common/Pagination.tsx
+++ b/components/common/Pagination.tsx
@@ -41,13 +41,15 @@ const Pagination = ({ total, limit, page, setPage }: PaginationProps) => {
   if (numPages <= 1) return null;
 
   return (
-    <nav className="mt-4 flex items-center gap-2">
+    <nav className="mt-4 flex items-center justify-center gap-1 sm:gap-2">
+      {/* Prev */}
       <button
         onClick={() => setPage(page - 1)}
         disabled={page === 1}
-        className={`flex h-[40px] w-[40px] items-center justify-center rounded ${page === 1 ? 'cursor-default opacity-40' : 'hover:bg-gray-100'} `}>
+        className={`flex h-[32px] w-[32px] items-center justify-center rounded sm:h-[40px] sm:w-[40px] ${page === 1 ? 'cursor-default opacity-40' : 'hover:bg-gray-100'} `}>
         &lt;
       </button>
+
       {/* Page Numbers */}
       {Array.from({ length: numPages }, (_, i) => {
         const isActive = page === i + 1;
@@ -56,7 +58,7 @@ const Pagination = ({ total, limit, page, setPage }: PaginationProps) => {
             key={i + 1}
             onClick={() => setPage(i + 1)}
             aria-current={isActive ? 'page' : undefined}
-             className={`flex h-10 w-10 items-center justify-center rounded ${
+            className={`flex h-[32px] w-[32px] items-center justify-center rounded sm:h-[40px] sm:w-[40px] ${
               isActive
                 ? 'border-red-30 bg-red-30 text-white'
                 : 'hover:bg-gray-10'
@@ -66,10 +68,11 @@ const Pagination = ({ total, limit, page, setPage }: PaginationProps) => {
         );
       })}
 
+      {/* Next */}
       <button
         onClick={() => setPage(page + 1)}
         disabled={page === numPages}
-        className={`flex h-[40px] w-[40px] items-center justify-center rounded ${page === numPages ? 'cursor-default opacity-40' : 'hover:bg-gray-100'} `}>
+        className={`flex h-[32px] w-[32px] items-center justify-center rounded sm:h-[40px] sm:w-[40px] ${page === numPages ? 'cursor-default opacity-40' : 'hover:bg-gray-100'} `}>
         &gt;
       </button>
     </nav>


### PR DESCRIPTION
## 📌 관련 이슈

<!-- 이슈를 자동으로 닫으려면: Closes #123 -->
<!-- 단순 참조만 하려면: Related to #123 -->

Closes #3 

## 🎯 작업 내용

페이지네이션 공통 컴포넌트 구현
- 전체 데이터 개수와 한 페이지당 보여줄 데이터 개수를 넣어서 활용하면 됩니다.
- 숫자를 누르거나 화살표로 이동할 수 있습니다.
- 선택된 번호는 하이라이팅됩니다.

- [x] 구현한 기능 설명

## ✅ 체크리스트

- [ ] 코드 리뷰 요청
- [x] 테스트 완료
- [ ] 문서 업데이트

## 📸 스크린샷 (선택사항)
<img width="580" height="68" alt="스크린샷 2025-11-19 오후 5 19 23" src="https://github.com/user-attachments/assets/42c69b3b-6a47-44bd-88f0-f8283aeed111" />

## 💬 추가 설명
사용 예제도 함께 적어두었습니다. 
