### PR TITLE
🐛Fix: 페이지네이션 버튼 최대 개수 지정

### DIFF
--- a/components/common/Pagination.tsx
+++ b/components/common/Pagination.tsx
@@ -40,30 +40,60 @@ const Pagination = ({ total, limit, page, setPage }: PaginationProps) => {
 
   if (numPages <= 1) return null;
 
+  // 최대 7개의 페이지 번호만 표시
+  const MAX_VISIBLE_PAGES = 7;
+
+  const getPageNumbers = () => {
+    // 전체 페이지가 7개 이하면 모두 표시
+    if (numPages <= MAX_VISIBLE_PAGES) {
+      return Array.from({ length: numPages }, (_, i) => i + 1);
+    }
+
+    // 현재 페이지를 중심으로 표시할 페이지 계산
+    const halfVisible = Math.floor(MAX_VISIBLE_PAGES / 2); // 3
+    let startPage = Math.max(1, page - halfVisible);
+    const endPage = Math.min(numPages, startPage + MAX_VISIBLE_PAGES - 1);
+
+    // 끝에 가까우면 시작 페이지 조정
+    if (endPage - startPage < MAX_VISIBLE_PAGES - 1) {
+      startPage = Math.max(1, endPage - MAX_VISIBLE_PAGES + 1);
+    }
+
+    return Array.from(
+      { length: endPage - startPage + 1 },
+      (_, i) => startPage + i
+    );
+  };
+
+  const pageNumbers = getPageNumbers();
+
   return (
     <nav className="mt-4 flex items-center justify-center gap-1 sm:gap-2">
       {/* Prev */}
       <button
         onClick={() => setPage(page - 1)}
         disabled={page === 1}
-        className={`flex h-[32px] w-[32px] items-center justify-center rounded sm:h-[40px] sm:w-[40px] ${page === 1 ? 'cursor-default opacity-40' : 'hover:bg-gray-100'} `}>
+        className={`flex h-[32px] w-[32px] items-center justify-center rounded sm:h-[40px] sm:w-[40px] ${
+          page === 1 ? 'cursor-default opacity-40' : 'hover:bg-gray-100'
+        }`}
+        aria-label="이전 페이지">
         &lt;
       </button>
 
       {/* Page Numbers */}
-      {Array.from({ length: numPages }, (_, i) => {
-        const isActive = page === i + 1;
+      {pageNumbers.map((pageNum) => {
+        const isActive = page === pageNum;
         return (
           <button
-            key={i + 1}
-            onClick={() => setPage(i + 1)}
+            key={pageNum}
+            onClick={() => setPage(pageNum)}
             aria-current={isActive ? 'page' : undefined}
             className={`flex h-[32px] w-[32px] items-center justify-center rounded sm:h-[40px] sm:w-[40px] ${
               isActive
                 ? 'border-red-30 bg-red-30 text-white'
                 : 'hover:bg-gray-10'
-            } `}>
-            {i + 1}
+            }`}>
+            {pageNum}
           </button>
         );
       })}
@@ -72,7 +102,10 @@ const Pagination = ({ total, limit, page, setPage }: PaginationProps) => {
       <button
         onClick={() => setPage(page + 1)}
         disabled={page === numPages}
-        className={`flex h-[32px] w-[32px] items-center justify-center rounded sm:h-[40px] sm:w-[40px] ${page === numPages ? 'cursor-default opacity-40' : 'hover:bg-gray-100'} `}>
+        className={`flex h-[32px] w-[32px] items-center justify-center rounded sm:h-[40px] sm:w-[40px] ${
+          page === numPages ? 'cursor-default opacity-40' : 'hover:bg-gray-100'
+        }`}
+        aria-label="다음 페이지">
         &gt;
       </button>
     </nav>


### PR DESCRIPTION
## 📌 관련 이슈

Closes #3 

## 🎯 작업 내용

- [ ] 구현한 기능 설명
- 페이지네이션의 visible 버튼 개수를 최대 7개로 제한

## ✅ 체크리스트

- [x] 코드 리뷰 요청
- [x] 테스트 완료
- [ ] 문서 업데이트

## 📸 스크린샷 (선택사항)

## 💬 추가 설명
