### PR TITLE
🐛 Fix: 공고 기존 시급 대비 인상률 수정 - 시급 상승 없을때 표현 수정

### DIFF
--- a/utils/transformNotice.ts
+++ b/utils/transformNotice.ts
@@ -13,7 +13,7 @@ export interface TransformedNotice {
   wage: number;
   imageUrl: string;
   isActive: boolean;
-  percentage: number;
+  percentage?: number;
   description?: string;
 }
 
@@ -23,11 +23,16 @@ export interface TransformedNotice {
 export const transformNoticeData = (notice: NoticeItem): TransformedNotice => {
   const originalPay = notice.shop.item.originalHourlyPay;
   const currentPay = notice.hourlyPay;
-  const percentage =
-    originalPay > 0
-      ? Math.round(((currentPay - originalPay) / originalPay) * 100)
-      : 0;
+  let percentage: number | undefined = undefined;
 
+  if (originalPay > 0) {
+    const diff = Math.round(((currentPay - originalPay) / originalPay) * 100);
+
+    // 인상률이 양수일 때만 노출
+    if (diff > 0) {
+      percentage = diff;
+    }
+  }
   return {
     id: notice.id,
     shopId: notice.shop.item.id,
@@ -48,8 +53,8 @@ export const calculatePercentage = (
   originalPay: number
 ): number | undefined => {
   if (!originalPay || originalPay <= 0) return undefined;
-  const percentage = Math.round(
-    ((currentPay - originalPay) / originalPay) * 100
-  );
-  return percentage > 0 ? percentage : undefined;
+
+  const diff = Math.round(((currentPay - originalPay) / originalPay) * 100);
+
+  return diff > 0 ? diff : undefined;
 };


### PR DESCRIPTION
---
name: 공고 기존 시급 대비 인상률 수정 - 시급 상승 없을때 표현 수정
---

## 📌 관련 이슈
#104
Closes #104

## 🎯 작업 내용

- [x] 시급 상승률 없을때 0 으로 표현되는거 뱃지 표현 안되게 수정
- [x]  동일하게 - 일때 뱃지 표현 안됨


## ✅ 체크리스트

- [x] 코드 리뷰 요청
- [x] 테스트 완료
- [ ] 문서 업데이트

## 📸 스크린샷 (선택사항)
<img width="330" height="379" alt="스크린샷 2025-12-03 오전 10 59 17" src="https://github.com/user-attachments/assets/752050b5-8075-4c17-9027-c7b2bc753e01" />

## 💬 추가 설명
